### PR TITLE
Remove redundant NSObject inheritance from APMAlertAction

### DIFF
--- a/Pod/Classes/APMAlertAction.swift
+++ b/Pod/Classes/APMAlertAction.swift
@@ -10,16 +10,18 @@ public enum APMAlertActionStyle {
     case Destructive
 }
 
-public class APMAlertAction : NSObject {
-    let title: String
-    let style: APMAlertActionStyle
-    let handler: ((APMAlertAction!) -> Void)!
+public protocol APMAlertActionProtocol {
+    var title: String { get }
+    var style: APMAlertActionStyle { get }
+    var handler: ((APMAlertActionProtocol) -> Void)? { get }
+}
 
-    public required init(coder aDecoder: NSCoder) {
-        fatalError("NSCoding not supported")
-    }
+public struct APMAlertAction: APMAlertActionProtocol {
+    public let title: String
+    public let style: APMAlertActionStyle
+    public let handler: ((APMAlertActionProtocol) -> Void)?
 
-    public init(title: String, style: APMAlertActionStyle, handler: ((APMAlertAction!) -> Void)!) {
+    public init(title: String, style: APMAlertActionStyle, handler: ((APMAlertActionProtocol) -> Void)?) {
         self.title = title
         self.style = style
         self.handler = handler

--- a/Pod/Classes/APMAlertController.swift
+++ b/Pod/Classes/APMAlertController.swift
@@ -31,7 +31,7 @@ public class APMAlertController: UIViewController {
     private var alertTitleImage: UIImage?
     private var alertMessage: String?
     private var alertAttributedMessage: NSAttributedString?
-    private var actions = [APMAlertAction]()
+    private var actions = [APMAlertActionProtocol]()
     private var buttons: [UIButton] = [] {
         didSet {
             buttonsView.removeConstraints(buttonsView.constraints)
@@ -270,7 +270,7 @@ public class APMAlertController: UIViewController {
         }
     }
 
-    public func addAction(action: APMAlertAction) {
+    public func addAction(action: APMAlertActionProtocol) {
         actions.append(action)
 
         let button = UIButton()
@@ -288,11 +288,10 @@ public class APMAlertController: UIViewController {
 
     func btnPressed(button: UIButton) {
         button.selected = true
-        let action = actions[button.tag - 1]
-        if (action.handler != nil) {
-            action.handler(action)
-        }
-        self.dismissViewControllerAnimated(true, completion: nil)
+        self.dismissViewControllerAnimated(true, completion: {
+            let action = self.actions[button.tag - 1]
+            action.handler?(action)
+        })
     }
 }
 


### PR DESCRIPTION
I create separate PR because this one have lower priority 
